### PR TITLE
Wrap the enrichment process with PII redaction.

### DIFF
--- a/3-enrich/scala-common-enrich/project/Dependencies.scala
+++ b/3-enrich/scala-common-enrich/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
 
   object V {
     // Java
-    val http             = "4.3.3"
+    val http             = "4.5.4"
     val commonsLang      = "3.4"
     val commonsIo        = "2.4"
     val commonsCodec     = "1.11"

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EventEnricher.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EventEnricher.scala
@@ -1,0 +1,50 @@
+package com.snowplowanalytics.snowplow.enrich.common.enrichments
+
+import com.snowplowanalytics.iglu.client.Resolver
+import com.snowplowanalytics.snowplow.enrich.common.ValidatedEnrichedEvent
+import com.snowplowanalytics.snowplow.enrich.common.adapters.RawEvent
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+import org.joda.time.DateTime
+
+/**
+ * A single-event enrichment process.
+ */
+trait EventEnricher {
+  def enrichEvent(event: RawEvent, etlVersion: String, etlTstamp: DateTime)(
+    implicit resolver: Resolver): ValidatedEnrichedEvent
+}
+
+/**
+ * Performs the standard event enrichment process implemented by the EnrichmentManager
+ * @param registry the configured enrichments
+ */
+class DefaultEventEnricher(private val registry: EnrichmentRegistry) extends EventEnricher {
+  override def enrichEvent(event: RawEvent, etlVersion: String, etlTstamp: DateTime)(
+    implicit resolver: Resolver): ValidatedEnrichedEvent =
+    EnrichmentManager.enrichEvent(registry, etlVersion, etlTstamp, event)
+}
+
+/**
+ * A wrapper for a enrichment process which performs cleansing of PII on the raw events
+ * prior to enrichment and reports any redacted data if enrichment doesn't reject the event.
+ * @param redactor the PII cleanser to use on raw events
+ * @param enricher the enrichment process being wrapped
+ * @param reporter the reporter for processing redaction events
+ */
+class RedactingEventEnricher(private val redactor: RawEventCleanser,
+                             private val enricher: EventEnricher,
+                             private val reporter: EventReporter)
+    extends EventEnricher {
+
+  override def enrichEvent(event: RawEvent, etlVersion: String, etlTstamp: DateTime)(
+    implicit resolver: Resolver): ValidatedEnrichedEvent = {
+    val (redactedEvent, redactedPiiTypes) = redactor.cleanse(event)
+    val enrichedEvent                     = enricher.enrichEvent(redactedEvent, etlVersion, etlTstamp)
+
+    def reportRedactedTypes(e: EnrichedEvent): Unit = redactedPiiTypes.foreach { reporter.reportRedactedEvent(e, _) }
+
+    enrichedEvent.foreach(reportRedactedTypes)
+
+    enrichedEvent
+  }
+}

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EventReporter.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EventReporter.scala
@@ -1,0 +1,49 @@
+package com.snowplowanalytics.snowplow.enrich.common.enrichments
+
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+import org.apache.http.client.utils.URIBuilder
+import scalaj.http.Http
+
+import scala.util.Try
+
+trait EventReporter {
+
+  /**
+   * Reports redactions performed on an event
+   * @param event the event which was redacted
+   * @param piiType the type of PII that was redacted
+   */
+  def reportRedactedEvent(event: EnrichedEvent, piiType: String): Unit
+}
+
+/**
+ * Reports redactions back to Snowplow as pii-redacted structured events.
+ * These events will have at least one context pointing at the redacted event.
+ * If the source event has an attached client context, this will be copied onto
+ * the redaction event.
+ *
+ * @param collectorHost the hostname of the Snowplow collector to which to send events
+ */
+class SnowplowEventReporter(private val collectorHost: String) extends EventReporter {
+
+  override def reportRedactedEvent(event: EnrichedEvent, piiType: String): Unit = {
+    val reportingUrl = generateUrl(event, piiType)
+    val req          = Http(reportingUrl)
+    Try(req.asBytes)
+  }
+
+  private def generateUrl(event: EnrichedEvent, piiType: String): String = {
+    val builder = new URIBuilder(collectorHost)
+    builder.setHost(collectorHost)
+    builder.setPath("/i")
+    builder.addParameter("e", "se")
+    builder.addParameter("se_ca", "pii")
+    builder.addParameter("se_ac", "redacted")
+    builder.addParameter("se_la", piiType)
+
+    val contexts = SnowplowEventFormatter.generateContexts(event)
+    builder.addParameter("co", contexts)
+
+    builder.toString
+  }
+}

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/PIIRedactor.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/PIIRedactor.scala
@@ -1,0 +1,229 @@
+package com.snowplowanalytics.snowplow.enrich.common.enrichments
+
+import java.net.URI
+import java.nio.charset.Charset
+import java.util.regex.Pattern
+
+import com.google.common.hash.Hashing
+import com.netaporter.uri.Uri
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.PIIRedactor._
+import com.snowplowanalytics.snowplow.enrich.common.utils.ConversionUtils
+import org.apache.http.NameValuePair
+import org.apache.http.client.utils.{URIBuilder, URLEncodedUtils}
+import org.apache.http.message.BasicNameValuePair
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+import scala.util.control.NonFatal
+
+case class RedactedValue(val replacement: String, val piiType: List[String])
+
+trait PIIRule {
+  def redact(value: String): RedactorResult
+}
+
+/**
+ * Redacts PII matching the full string.
+ * This is typically applied in a context where we suspect what kind of PII may be present.
+ * @param piiType the type of PII matched by the pattern.  For example, NAME or PHONE.
+ * @param valuePattern the pattern describing the PII.  If matched, the value will be redacted.
+ */
+class FullStringPIIDetector(val piiType: String, val valuePattern: Pattern) extends PIIRule {
+
+  def redact(value: String): RedactorResult =
+    if (!valuePattern.matcher(value).matches()) {
+      Left(value)
+    } else {
+      Right(RedactedValue(s"** REDACTED ${piiType.toUpperCase} **", List(piiType)))
+    }
+}
+
+/**
+ * Redacts email addresses.
+ * Since these are fairly recognizable, these can be detected anywhere within a string.
+ * When redacted, a hash of the redacted value will be included with the replacement.
+ * @param valuePattern the pattern to use to recognize email addresses.  Each match will be redacted.
+ */
+class EmailPIIDetector(val valuePattern: Pattern) extends PIIRule {
+
+  val piiType = "EMAIL"
+  val hasher  = Hashing.murmur3_128()
+
+  def redact(value: String): RedactorResult = {
+    val matcher = valuePattern.matcher(value)
+
+    if (matcher.find) {
+      val output = new StringBuffer
+      do {
+        matcher.appendReplacement(output, s"** REDACTED EMAIL [${generateHash(matcher.group)}] **")
+      } while (matcher.find)
+      matcher.appendTail(output)
+      return Right(RedactedValue(output.toString, List(piiType)))
+    }
+    return Left(value)
+  }
+
+  private def generateHash(value: String) =
+    hasher.hashString(value, Charset.forName("UTF-8")).toString
+}
+
+object PIIRedactor {
+
+  type RedactorResult = Either[String, RedactedValue]
+
+  private val anyNonEmptyPattern = Pattern.compile(".+")
+  // Expect at least two digits to avoid false positives for common use case with 0/1 as boolean flag
+  private val phonePattern = Pattern.compile("(?U:[\\d\\s()+\\-]{2,})")
+  private val emailPattern = Pattern.compile(
+    "(?U:\\p{Alnum}[\\p{Alnum}.!#$%&'*+/=?^_`{|}~\\-]+@\\p{Alnum}[\\p{Alnum}\\-]+(\\.[\\p{Alnum}\\-]+)+)")
+
+  private val name: PIIRule     = new FullStringPIIDetector("NAME", anyNonEmptyPattern)
+  private val account: PIIRule  = new FullStringPIIDetector("ACCOUNT", anyNonEmptyPattern)
+  private val password: PIIRule = new FullStringPIIDetector("PASSWORD", anyNonEmptyPattern)
+  private val phone: PIIRule    = new FullStringPIIDetector("PHONE", phonePattern)
+  private val email: PIIRule    = new EmailPIIDetector(emailPattern)
+
+  // Use lowercase keys; we fold to lowercase for parameter matching
+  private val parameterValueRules: Map[String, PIIRule] = Map(
+    "firstname"    -> name,
+    "first-name"   -> name,
+    "fname"        -> name,
+    "lastname"     -> name,
+    "last-name"    -> name,
+    "lname"        -> name,
+    "surname"      -> name,
+    "name"         -> name,
+    "fullname"     -> name,
+    "username"     -> account,
+    "user-name"    -> account,
+    "user"         -> account,
+    "un"           -> account,
+    "password"     -> password,
+    "passwd"       -> password,
+    "pass"         -> password,
+    "pw"           -> password,
+    "tel"          -> phone,
+    "tele"         -> phone,
+    "telephone"    -> phone,
+    "phone"        -> phone,
+    "phonenum"     -> phone,
+    "phonenumber"  -> phone,
+    "phone-number" -> phone,
+    "ph"           -> phone,
+    "mob"          -> phone,
+    "mobile"       -> phone
+  )
+
+  private val genericRules: List[PIIRule] = List(email)
+
+  def apply() = new PIIRedactor(parameterValueRules, genericRules)
+
+  private def extractParameters(uri: URI, encoding: String): Option[List[NameValuePair]] = {
+    def asNameValue(value: (String, Option[String])): NameValuePair =
+      new BasicNameValuePair(value._1, value._2.getOrElse(""))
+
+    Try(URLEncodedUtils.parse(uri, encoding).asScala)
+      .recoverWith {
+        case NonFatal(_) => {
+          Try(Uri.parse(uri.toString).query.params.map(asNameValue))
+        }
+      }
+      .toOption
+      .map(_.toList)
+  }
+
+  private def applyRedactions(parameters: List[NameValuePair],
+                              redactions: Map[NameValuePair, RedactedValue]): List[NameValuePair] =
+    parameters.map { parameter =>
+      val redaction = redactions.get(parameter).map(_.replacement)
+      redaction.map(new BasicNameValuePair(parameter.getName, _)).getOrElse(parameter)
+    }
+
+  private def replaceParameters(uri: URI, encoding: String, replacements: List[NameValuePair]): String = {
+    val buffer = new URIBuilder()
+      .setScheme(uri.getScheme)
+      .setHost(uri.getHost)
+      .setPort(uri.getPort)
+      .setPath(uri.getPath)
+      .setParameters(replacements.asJava)
+      .setFragment(uri.getFragment)
+      .setCharset(Charset.forName(encoding))
+
+    buffer.toString
+  }
+
+  private def getRedactedPIITypes(redactions: Map[NameValuePair, RedactedValue]): List[String] =
+    redactions.values.flatMap(_.piiType).toList
+}
+
+class PIIRedactor(private val parameterValueRules: Map[String, PIIRule], private val genericRules: List[PIIRule]) {
+
+  /**
+   * Redacts any query parameters of a URL which are suspected to contain PII.
+   * This is driven by parameter name, providing context as to the type of PII contained.
+   * For all parameters, generic redactions will also be applied, as they
+   * need no context.
+   *
+   * @param url the url on which to perform redaction.  If this cannot be parsed, no redaction is performed.
+   * @param encoding the encoding of the URL
+   * @return the redaction performed.  Redactions should preserve the original structure of the input,
+   *         excluding any normalization due to URL decoding/encoding roundtrip.
+   */
+  def cleanseUrlParameters(url: String, encoding: String): Option[RedactedValue] =
+    for {
+      uri        <- ConversionUtils.stringToUri(url).getOrElse(None)
+      parameters <- extractParameters(uri, encoding)
+      redactions <- getRedactions(parameters)
+    } yield {
+      val updatedParameters = applyRedactions(parameters, redactions)
+      RedactedValue(replaceParameters(uri, encoding, updatedParameters), getRedactedPIITypes(redactions))
+    }
+
+  private def getRedactions(parameters: List[NameValuePair]): Option[Map[NameValuePair, RedactedValue]] = {
+    val redactions = parameters.flatMap { parameter =>
+      redactQueryParameter(parameter.getName, parameter.getValue).map((parameter, _))
+    }
+    if (redactions.isEmpty) None else Some(redactions.toMap)
+  }
+
+  private def redactQueryParameter(parameter: String, value: String): Option[RedactedValue] =
+    if (value == null) {
+      // Nothing to redact!
+      None
+    } else {
+      def applyRule(rule: PIIRule): Option[RedactedValue] = rule.redact(value).right.toOption
+
+      lookupParameterRule(parameter).flatMap(applyRule).orElse(cleanseString(value))
+    }
+
+  private def lookupParameterRule(parameter: String): Option[PIIRule] =
+    parameterValueRules.get(parameter.toLowerCase)
+
+  /**
+   * Performs redaction on text.  Only generic redaction rules are applied, as
+   * there is no additional context for guidance.
+   * @param value the text on which to perform redaction
+   * @return the redaction performed
+   */
+  def cleanseString(value: String): Option[RedactedValue] =
+    if (value == null) {
+      // Nothing to redact!
+      None
+    } else {
+      val initialResult: RedactorResult = Left(value)
+      genericRules.foldLeft(initialResult)(applyRule).right.toOption
+    }
+
+  private def applyRule(result: RedactorResult, rule: PIIRule): RedactorResult =
+    result match {
+      case Left(value) => rule.redact(value)
+      case Right(RedactedValue(replacement, piiType)) => {
+        rule.redact(replacement) match {
+          case Right(RedactedValue(newReplacement, newPiiType)) =>
+            Right(RedactedValue(newReplacement, piiType ++ newPiiType))
+          case Left(_) => result
+        }
+      }
+    }
+
+}

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/RawEventCleanser.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/RawEventCleanser.scala
@@ -1,0 +1,96 @@
+package com.snowplowanalytics.snowplow.enrich.common.enrichments
+
+import com.snowplowanalytics.snowplow.enrich.common.adapters._
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.RawEventCleanser._
+import com.snowplowanalytics.snowplow.enrich.common.utils.ConversionUtils
+
+trait EventAttribute {
+  def getValue(event: RawEvent): Option[String]
+
+  def updateValue(event: RawEvent, update: String): RawEvent
+}
+
+private class Parameter(val name: String) extends EventAttribute {
+  override def getValue(event: RawEvent): Option[String] = event.parameters.get(name)
+
+  override def updateValue(event: RawEvent, update: String): RawEvent =
+    event.copy(parameters = event.parameters + (name -> update))
+}
+
+private class Base64Parameter(name: String) extends Parameter(name) {
+  override def getValue(event: RawEvent): Option[String] = {
+    val encodedValue = super.getValue(event)
+    encodedValue.flatMap(ConversionUtils.decodeBase64Url(name, _).toOption)
+  }
+
+  override def updateValue(event: RawEvent, update: String): RawEvent = {
+    val encodedValue = ConversionUtils.encodeBase64Url(update)
+    super.updateValue(event, encodedValue)
+  }
+}
+
+private class ContextReferer() extends EventAttribute {
+  override def getValue(event: RawEvent): Option[String] = event.context.refererUri
+
+  override def updateValue(event: RawEvent, update: String): RawEvent =
+    event.copy(context = event.context.copy(refererUri = Some(update)))
+}
+
+object RawEventCleanser {
+  type AttributeRedactor = Function1[String, Option[RedactedValue]]
+
+  private val refererParameter         = new Parameter("refr")
+  private val urlParameter             = new Parameter("url")
+  private val contextReferer           = new ContextReferer
+  private val contextsParameter        = new Parameter("co")
+  private val encodedContextsParameter = new Base64Parameter("cx")
+
+  private def cleanAttributes(event: RawEvent,
+                              cleansings: Map[EventAttribute, AttributeRedactor]): Map[EventAttribute, RedactedValue] =
+    cleansings.flatMap {
+      case (attribute, cleanser) => cleanseAttribute(event, attribute, cleanser).map((attribute, _))
+    }
+
+  private def cleanseAttribute(event: RawEvent,
+                               attribute: EventAttribute,
+                               cleanser: AttributeRedactor): Option[RedactedValue] =
+    attribute.getValue(event).flatMap(cleanser)
+
+  private def applyRedactions(event: RawEvent, redactions: Map[EventAttribute, RedactedValue]): RawEvent =
+    redactions.foldLeft(event)(applyRedaction)
+
+  private def applyRedaction(event: RawEvent, redaction: (EventAttribute, RedactedValue)): RawEvent =
+    redaction match {
+      case (update, value) => update.updateValue(event, value.replacement)
+    }
+
+  def apply(): RawEventCleanser =
+    new RawEventCleanser(PIIRedactor())
+}
+
+class RawEventCleanser(val redactor: PIIRedactor) {
+
+  /**
+   * Cleanses a raw event of PII in the page/referrer URLs and the contexts.
+   * @param event the event to cleanse
+   * @return a tuple of a clean version of the event and the set of PII types found
+   */
+  def cleanse(event: RawEvent): (RawEvent, Set[String]) = {
+    val urlCleanser: AttributeRedactor    = redactor.cleanseUrlParameters(_, event.source.encoding)
+    val stringCleanser: AttributeRedactor = redactor.cleanseString(_)
+
+    val cleansings = Map(
+      refererParameter         -> urlCleanser,
+      urlParameter             -> urlCleanser,
+      contextReferer           -> urlCleanser,
+      contextsParameter        -> stringCleanser,
+      encodedContextsParameter -> stringCleanser
+    )
+
+    val redactions = cleanAttributes(event, cleansings)
+
+    val cleanEvent = applyRedactions(event, redactions)
+
+    (cleanEvent, redactions.values.flatMap(_.piiType).toSet)
+  }
+}

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/SnowplowEventFormatter.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/SnowplowEventFormatter.scala
@@ -1,0 +1,52 @@
+package com.snowplowanalytics.snowplow.enrich.common.enrichments
+
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+import org.json4s.JValue
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+
+import scala.util.Try
+
+private case class Schema(val name: String) {
+  def hasSchema(obj: JValue): Boolean =
+    obj \ "schema" match {
+      case JString(value) => name == value
+      case _              => false
+    }
+}
+
+/**
+ * Formats the contexts for a pii-redacted event.
+ * We capture the id and, if possible, the client context of the event.
+ */
+object SnowplowEventFormatter {
+
+  private val clientSchema   = Schema("iglu:com.onespot/client/jsonschema/1-0-0")
+  private val contextsSchema = Schema("iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1")
+
+  /**
+   * Builds the relevant contexts for a redaction event.
+   * @param event the source event which was redacted
+   * @return the contexts to send with the reported redaction event
+   */
+  def generateContexts(event: EnrichedEvent): String = {
+    val contexts = List(Some(parent(event.event_id)), clientContext(event)).flatten
+    val contextJson =
+      ("schema" -> contextsSchema.name) ~
+        ("data" -> JArray(contexts))
+    compact(render(contextJson))
+  }
+
+  private def parent(eventId: String): JValue =
+    ("schema" -> "iglu:com.snowplowanalytics.snowplow/parent_event/jsonschema/1-0-0") ~
+      ("data" -> ("parentEventId" -> eventId))
+
+  private def clientContext(event: EnrichedEvent): Option[JValue] =
+    for {
+      wrapper <- Try(parse(event.contexts)).filter(contextsSchema.hasSchema).toOption
+    } yield {
+      val contexts = wrapper \ "data"
+      contexts.find(clientSchema.hasSchema)
+    }
+}

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/PIIRedactorSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/PIIRedactorSpec.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2012-2018 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.common.enrichments
+
+import java.util.regex.Pattern
+
+// Specs2
+import org.specs2.matcher.DataTables
+import org.specs2.scalaz.ValidationMatchers
+import org.specs2.{ScalaCheck, Specification}
+
+class PIIRedactorSpec extends Specification with DataTables with ValidationMatchers with ScalaCheck {
+  def is = s2"""
+  This is a specification to test the PIICleanser
+  Invalid URL is left unchanged                                                                              $e1
+  URL unchanged if no matching query parameters                                                              $e2
+  Redacts values from matching query parameters                                                              $e3
+  Value unchanged if no matches                                                                              $e4
+  Matching substrings redacted                                                                               $e5
+  """
+
+  val badURL = "http:test.com"
+
+  val encoding = "UTF-8"
+
+  val fooPII   = new FullStringPIIDetector("FOO", Pattern.compile("A.*A"))
+  val barPII   = new FullStringPIIDetector("BAR", Pattern.compile("B.*B"))
+  val emailPII = new EmailPIIDetector(Pattern.compile("\\w+@\\w+"))
+
+  val redactor = new PIIRedactor(Map("foo" -> fooPII, "bar" -> barPII), List(emailPII))
+
+  def e1 = redactor.cleanseUrlParameters(badURL, encoding) must beNone
+
+  def e2 =
+    "SPEC NAME"                              || "URL" |
+      "No matching parameter preserves URL"  !! "http://test.com/test?foobar=AA" |
+      "Value not matching preserves URL"     !! "http://test.com/test?foo=BB"|
+      "No value for parameter preserves URL" !! "http://test.com/test?foo" |> { (_, input) =>
+      {
+        redactor.cleanseUrlParameters(input, encoding) must beNone
+      }
+    }
+
+  def e3 =
+    "SPEC NAME"              || "URL"                                | "REDACTED_URL" | "REDACTED_PII" |
+      "Match replaces value" !! "http://test.com/test?foo=AA&baz=BB" ! "http://test.com/test?foo=**+REDACTED+FOO+**&baz=BB" ! List(
+        "FOO") |
+      "Parameter match is case-insensitive" !! "http://test.com/test?FoO=AA&baz=BB" ! "http://test.com/test?FoO=**+REDACTED+FOO+**&baz=BB" ! List(
+        "FOO") |
+      "Multiple matching copies same param replaced" !! "http://test.com/test?foo=AA&foo=BB&foo=AZA" ! "http://test.com/test?foo=**+REDACTED+FOO+**&foo=BB&foo=**+REDACTED+FOO+**" ! List(
+        "FOO",
+        "FOO") |
+      "Multiple matching different params replaced" !! "http://test.com/test?bar=BB&foo=AA&baz=BB" ! "http://test.com/test?bar=**+REDACTED+BAR+**&foo=**+REDACTED+FOO+**&baz=BB" ! List(
+        "BAR",
+        "FOO") |
+      "Generic rules applied to query parameters" !! "http://test.com/test?foo=X@Y&baz=BB" ! "http://test.com/test?foo=**+REDACTED+EMAIL+%5B03e4ff391b3302dcddcc25f86ae43170%5D+**&baz=BB" ! List(
+        "EMAIL") |
+      "Generic rules applied to all query parameters" !! "http://test.com/test?foo=X@Y&baz=B+X@Y+B" ! "http://test.com/test?foo=**+REDACTED+EMAIL+%5B03e4ff391b3302dcddcc25f86ae43170%5D+**&baz=B+**+REDACTED+EMAIL+%5B03e4ff391b3302dcddcc25f86ae43170%5D+**+B" ! List(
+        "EMAIL",
+        "EMAIL") |> { (_, input, redactedUrl, redactedPii) =>
+      {
+        redactor.cleanseUrlParameters(input, encoding) must beSome(RedactedValue(redactedUrl, redactedPii))
+      }
+    }
+
+  def e4 = redactor.cleanseString("no email match") must beNone
+
+  def e5 =
+    "SPEC NAME"                     || "VALUE"                     | "REDACTED VALUE" |
+      "Matches full string"         !! "abc@xyz"                   ! "** REDACTED EMAIL [fd48cb4c4ccb8506a014f110a28b941f] **" |
+      "Matches substring"           !! "Prefix abc@xyz suffix"     ! "Prefix ** REDACTED EMAIL [fd48cb4c4ccb8506a014f110a28b941f] ** suffix" |
+      "Matches multiple substrings" !! "Values: abc@xyz, xyz@a123" ! "Values: ** REDACTED EMAIL [fd48cb4c4ccb8506a014f110a28b941f] **, ** REDACTED EMAIL [767c8e560c69b07ba75b4ddf0c4840cc] **" |> {
+      (_, value, redactedValue) =>
+        {
+          redactor.cleanseString(value) must beSome(RedactedValue(redactedValue, List("EMAIL")))
+        }
+    }
+
+}

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/RawEventCleanserSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/RawEventCleanserSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2012-2018 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.common.enrichments
+
+import com.snowplowanalytics.snowplow.enrich.common.adapters.RawEvent
+import com.snowplowanalytics.snowplow.enrich.common.loaders.{CollectorApi, CollectorContext, CollectorSource}
+import com.snowplowanalytics.snowplow.enrich.common.utils.ConversionUtils.encodeBase64Url
+
+// Specs2
+import org.specs2.matcher.DataTables
+import org.specs2.scalaz.ValidationMatchers
+import org.specs2.{ScalaCheck, Specification}
+
+object RawEventCleanserSpec {
+
+  implicit class TestEvent(event: RawEvent) {
+    def withParameter(parameter: String, value: String): RawEvent =
+      event.copy(parameters = event.parameters + (parameter -> value))
+
+    def withRefererUri(refererUri: String): RawEvent =
+      event.copy(context = event.context.copy(refererUri = Some(refererUri)))
+  }
+
+}
+
+class RawEventCleanserSpec extends Specification with DataTables with ValidationMatchers with ScalaCheck {
+  def is = s2"""
+  Redacts PII events                                                                                 $e1
+  """
+
+  val cleanser = new RawEventCleanser(PIIRedactor())
+
+  val testCollector                       = CollectorApi("test", "0.1.2")
+  val testSource                          = CollectorSource("name", "UTF-8", None)
+  val baseParameters: Map[String, String] = Map.empty
+  val baseContext                         = CollectorContext(None, None, None, None, List.empty, None)
+
+  val rawEvent = RawEvent(testCollector, baseParameters, None, testSource, baseContext)
+
+  val testURL = "http://test.com?firstname=Albert&lastname=Aardvark&phone=123 456 7890"
+  val redactedURL =
+    "http://test.com?firstname=**+REDACTED+NAME+**&lastname=**+REDACTED+NAME+**&phone=**+REDACTED+PHONE+**"
+  val urlRedactedPII = Set("NAME", "PHONE")
+
+  val testContexts =
+    "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1\",\"data\":[{\"schema\":\"iglu:com.onespot/user-id/jsonschema/1-0-0\",\"data\":{\"source\":\"email\",\"user_id\":\"test@abc.com\"}}]}"
+  val redactedContexts =
+    "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1\",\"data\":[{\"schema\":\"iglu:com.onespot/user-id/jsonschema/1-0-0\",\"data\":{\"source\":\"email\",\"user_id\":\"** REDACTED EMAIL [c902dbf600dd522e5a3b226b121974c0] **\"}}]}"
+  val contextRedactedPII = Set("EMAIL")
+
+  def e1 =
+    "SPEC NAME"                          || "Source Event" | "Cleansed Event" | "PII Types" |
+      "Redacts PII in referer url"       !! withParameter("refr", testURL) ! withParameter("refr", redactedURL) ! urlRedactedPII |
+      "Redacts PII in page url"          !! withParameter("url", testURL) ! withParameter("url", redactedURL) ! urlRedactedPII |
+      "Redacts PII in context url"       !! withContextReferer(testURL) ! withContextReferer(redactedURL) ! urlRedactedPII |
+      "Redacts PII in unencoded context" !! withParameter("co", testContexts) ! withParameter("co", redactedContexts) ! contextRedactedPII |
+      "Redacts PII in encoded context"   !! withBase64Parameter("cx", testContexts) ! withBase64Parameter(
+        "cx",
+        redactedContexts) ! contextRedactedPII |> { (_, event, cleansedEvent, redactedPiiTypes) =>
+      {
+        cleanser.cleanse(event) mustEqual (cleansedEvent, redactedPiiTypes)
+      }
+    }
+
+  def withParameter(parameter: String, value: String): RawEvent =
+    rawEvent.copy(parameters = rawEvent.parameters + (parameter -> value))
+
+  def withBase64Parameter(parameter: String, value: String): RawEvent =
+    rawEvent.copy(parameters = rawEvent.parameters + (parameter -> encodeBase64Url(value)))
+
+  def withContextReferer(refererUri: String): RawEvent =
+    rawEvent.copy(context = rawEvent.context.copy(refererUri = Some(refererUri)))
+}

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/SnowplowEventFormatterSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/SnowplowEventFormatterSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2012-2018 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.common.enrichments
+
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+import org.scalacheck.Arbitrary
+
+// Specs2
+import org.specs2.matcher.DataTables
+import org.specs2.scalaz.ValidationMatchers
+import org.specs2.{ScalaCheck, Specification}
+
+class SnowplowEventFormatterSpec extends Specification with DataTables with ValidationMatchers with ScalaCheck {
+  def is = s2"""
+  Always includes parent context                                                                                 $p1
+  Copies client context if present                                                                               $e2
+  """
+
+  def idStringGen = EventEnrichments.generateEventId()
+
+  implicit def idStrings: Arbitrary[String] = Arbitrary(idStringGen)
+
+  val p1 = prop((id: String) => {
+    val event    = makeEvent(id)
+    val contexts = SnowplowEventFormatter.generateContexts(event)
+    val expected =
+      s"""{"schema":"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1","data":[{"schema":"iglu:com.snowplowanalytics.snowplow/parent_event/jsonschema/1-0-0","data":{"parentEventId":"${id}"}}]}"""
+    contexts mustEqual expected
+  })
+
+  def testId = "dummyId"
+  def parentEventContext =
+    "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/parent_event/jsonschema/1-0-0\",\"data\":{\"parentEventId\":\"dummyId\"}}"
+
+  def userContext =
+    "{\"schema\":\"iglu:com.onespot/user-id/jsonschema/1-0-0\",\"data\":{\"source\":\"email\",\"user_id\":\"3458\"}}"
+
+  def clientContext =
+    "{\"schema\":\"iglu:com.onespot/client/jsonschema/1-0-0\",\"data\":{\"company_id\":1,\"site_id\":2}}"
+
+  // Should find client context if present
+  def e2 =
+    "SPEC NAME"           || "Event contexts" | "Output contexts" |
+      "Invalid json "     !! "bad { json }" ! contexts(parentEventContext) |
+      "No schema present" !! "{ \"noschema\": 1 }" ! contexts(parentEventContext) |
+      "Wrong root schema" !! "{ \"schema\": \"foo\" }" ! contexts(parentEventContext) |
+      "No data field"     !! "{ \"schema\": \"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1\" }" ! contexts(
+        parentEventContext) |
+      "Wrong data type" !! "{ \"schema\": \"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1\", \"data\": 1 }" ! contexts(
+        parentEventContext)   |
+      "No client context"     !! contexts(userContext) ! contexts(parentEventContext) |
+      "Client context copied" !! contexts(s"${userContext},${clientContext}") ! contexts(
+        s"${parentEventContext},${clientContext}") |> { (_, input, output) =>
+      {
+        val event    = makeEvent(testId, input)
+        val contexts = SnowplowEventFormatter.generateContexts(event)
+        contexts mustEqual output
+      }
+    }
+
+  def makeEvent(id: String, contexts: String = ""): EnrichedEvent = {
+    val event = new EnrichedEvent
+    event.event_id = id
+    event.contexts = contexts
+    event
+  }
+
+  def contexts(contexts: String): String =
+    s"""{"schema":"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1","data":[${contexts}]}"""
+}

--- a/3-enrich/spark-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.spark/EnrichJobSpec.scala
+++ b/3-enrich/spark-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.spark/EnrichJobSpec.scala
@@ -696,6 +696,8 @@ trait EnrichJobSpec extends SparkSpec {
       igluConfig,
       "--etl-timestamp",
       1000000000000L.toString,
+      "--redaction-collector",
+      "http://localhost",
       "--local"
     )
 

--- a/3-enrich/spark-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.spark/PiiRedactionSpec.scala
+++ b/3-enrich/spark-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.spark/PiiRedactionSpec.scala
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2012-2018 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and
+ * limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.spark
+
+import org.specs2.mutable.Specification
+
+object PiiRedactionSpec {
+  import EnrichJobSpec._
+  val contexts =
+    """eyJkYXRhIjpbeyJzY2hlbWEiOiJpZ2x1OmNvbS5zbm93cGxvd2FuYWx5dGljcy5zbm93cGxvdy9jb250ZXh0cy9qc29uc2NoZW1hLzEtMC0xIiwiZGF0YSI6W3sic2NoZW1hIjoiaWdsdTpjb20ub25lc3BvdC91c2VyLWlkL2pzb25zY2hlbWEvMS0wLTAiLCJkYXRhIjp7InNvdXJjZSI6ImVtYWlsIiwidXNlcl9pZCI6InRlc3RAYWJjLmNvbSJ9fV19LHsiZGF0YSI6eyJsb25naXR1ZGUiOjEwLCJiZWFyaW5nIjo1MCwic3BlZWQiOjE2LCJhbHRpdHVkZSI6MjAsImFsdGl0dWRlQWNjdXJhY3kiOjAuMywibGF0aXR1ZGVMb25naXR1ZGVBY2N1cmFjeSI6MC41LCJsYXRpdHVkZSI6N30sInNjaGVtYSI6ImlnbHU6Y29tLnNub3dwbG93YW5hbHl0aWNzLnNub3dwbG93L2dlb2xvY2F0aW9uX2NvbnRleHQvanNvbnNjaGVtYS8xLTAtMCJ9XSwic2NoZW1hIjoiaWdsdTpjb20uc25vd3Bsb3dhbmFseXRpY3Muc25vd3Bsb3cvY29udGV4dHMvanNvbnNjaGVtYS8xLTAtMCJ9"""
+
+  val lines = Lines(
+    s"2012-05-24  00:06:42  LHR5  3402  216.160.83.56  GET d3gs014xn8p70.cloudfront.net  /ice.png  200 http://www.psychicbazaar.com/crystals/335-howlite-tumble-stone.html?firstname=bob?novalue Mozilla/5.0%20(iPhone;%20CPU%20iPhone%20OS%205_1_1%20like%20Mac%20OS%20X)%20AppleWebKit/534.46%20(KHTML,%20like%20Gecko)%20Version/5.1%20Mobile/9B206%20Safari/7534.48.3  &e=pv&cx=$contexts&eid=550e8400-e29b-41d4-a716-446655440000&page=Psychic%20Bazaar%09Shop&dtm=1364219529188&tid=637309&vp=2560x935&ds=2543x1273&vid=41&duid=9795bd0203804cd1&p=web&tv=js-0.11.1&fp=2876815413&aid=pbzsite&lang=en-GB&cs=UTF-8&tz=Europe%2FLondon&refr=http%253A%252F%252Fwww.google.com%252Fsearch%253Fq%253Dgateway%252Boracle%252Bcards%252Bdenise%252Blinn%2526hl%253Den%2526client%253Dsafari%2526name%253Drobert&f_pdf=1&f_qt=0&f_realp=0&f_wma=0&f_dir=0&f_fla=1&f_java=1&f_gears=0&f_ag=1&res=2560x1440&cd=32&cookie=1&url=http%3A%2F%2Fwww.psychicbazaar.com%2Fcrystals%2F335-howlite-tumble-stone.html%3Ffirstname%3Dbob%26novalue&cv=clj-0.5.0-tom-0.0.4"
+  )
+  val expected = List(
+    "pbzsite",
+    "web",
+    etlTimestamp,
+    "2012-05-24 00:06:42.000",
+    "2013-03-25 13:52:09.188",
+    "page_view",
+    "550e8400-e29b-41d4-a716-446655440000", // event_id is present in the querystring
+    "637309",
+    null, // No tracker namespace
+    "js-0.11.1",
+    "clj-0.5.0-tom-0.0.4",
+    etlVersion,
+    null, // No user_id set
+    "a56b2a47752ef6dac5d5c2d9cbebf2fd69fd1f36",
+    "2876815413",
+    "9795bd0203804cd1",
+    "41",
+    null, // No network_userid set
+    "US", // US geolocation
+    "WA",
+    "Milton",
+    "98354",
+    "47.2513",
+    "-122.3149",
+    "Washington",
+    "Century Link", // Using the ISP lookup service
+    "Lariat Software",
+    null,
+    null,
+    "http://www.psychicbazaar.com/crystals/335-howlite-tumble-stone.html?firstname=**+REDACTED+NAME+**&novalue",
+    "Psychic Bazaar    Shop",
+    "http://www.google.com/search?q=gateway+oracle+cards+denise+linn&hl=en&client=safari&name=**+REDACTED+NAME+**",
+    "http",
+    "www.psychicbazaar.com",
+    "80",
+    "/crystals/335-howlite-tumble-stone.html",
+    "firstname=**+REDACTED+NAME+**&novalue",
+    null,
+    "http",
+    "www.google.com",
+    "80",
+    "/search",
+    "q=gateway+oracle+cards+denise+linn&hl=en&client=safari&name=**+REDACTED+NAME+**",
+    null,
+    "search", // Search referer
+    "Google",
+    "gateway oracle cards denise linn",
+    null, // No marketing campaign info
+    null, //
+    null, //
+    null, //
+    null, //
+    """{"data":[{"schema":"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1","data":[{"schema":"iglu:com.onespot/user-id/jsonschema/1-0-0","data":{"source":"email","user_id":"** REDACTED EMAIL [c902dbf600dd522e5a3b226b121974c0] **"}}]},{"data":{"longitude":10,"bearing":50,"speed":16,"altitude":20,"altitudeAccuracy":0.3,"latitudeLongitudeAccuracy":0.5,"latitude":7},"schema":"iglu:com.snowplowanalytics.snowplow/geolocation_context/jsonschema/1-0-0"}],"schema":"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0"}""", // Custom context
+    null, // Structured event fields empty
+    null, //
+    null, //
+    null, //
+    null, //
+    null, // Unstructured event field empty
+    null, // Transaction fields empty
+    null, //
+    null, //
+    null, //
+    null, //
+    null, //
+    null, //
+    null, //
+    null, // Transaction item fields empty
+    null, //
+    null, //
+    null, //
+    null, //
+    null, //
+    null, // Page ping fields are empty
+    null, //
+    null, //
+    null, //
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3",
+    "Mobile Safari",
+    "Safari",
+    "5.1",
+    "Browser (mobile)",
+    "WEBKIT",
+    "en-GB",
+    "1",
+    "1",
+    "1",
+    "0",
+    "0",
+    "0",
+    "0",
+    "0",
+    "1",
+    "1",
+    "32",
+    "2560",
+    "935",
+    "iOS 5 (iPhone)",
+    "iOS",
+    "Apple Inc.",
+    "Europe/London",
+    "Mobile",
+    "1",
+    "2560",
+    "1440",
+    "UTF-8",
+    "2543",
+    "1273"
+  )
+}
+
+/**
+ * Run an event with embedded PII and validate redaction
+ */
+class PiiRedactionSpec extends Specification with EnrichJobSpec {
+  import EnrichJobSpec._
+  override def appName = "page-view-cf-lines"
+  sequential
+  "A job which processes a CloudFront file containing an event with PII in URLs and contexts" should {
+    // Anonymize 1 IP address quartet
+    runEnrichJob(PiiRedactionSpec.lines, "cloudfront", "1", true, List("geo", "isp"))
+
+    "correctly redacts PII in URL parameters and contexts" in {
+      val Some(goods) = readPartFile(dirs.output)
+      goods.size must_== 1
+      val actual = goods.head.split("\t").map(s => if (s.isEmpty()) null else s)
+      for (idx <- PiiRedactionSpec.expected.indices) {
+        actual(idx) must BeFieldEqualTo(PiiRedactionSpec.expected(idx), idx)
+      }
+    }
+
+    "not write any bad rows" in {
+      dirs.badRows must beEmptyDir
+    }
+  }
+}


### PR DESCRIPTION
Performs redaction on the raw events pre-enrichment, helping reduce potential spread of PII by enrichment and reducing the number places we have to check.
We look for email addresses generically across URLs and event contexts.
For more contextually sensitive PII, such as names, we restrict to looking at query parameters in URLs, using the parameter name as context.
Any redactions for events not rejected by enrichment are reported back to Snowplow as pii-redacted events.
These will contain a context pointing back to the parent event and, if present, the client context from the source event.
